### PR TITLE
Conform to MutableCollection and add test

### DIFF
--- a/NonEmptyArray/NonEmptyArray.swift
+++ b/NonEmptyArray/NonEmptyArray.swift
@@ -141,12 +141,19 @@ extension NonEmptyArray: Collection {
         return count
     }
     
-    public subscript(_ index: Int) -> Element {
-        return elements[index]
-    }
-    
     public func index(after i: Int) -> Int {
         return i + 1
+    }
+}
+
+extension NonEmptyArray: MutableCollection {
+    public subscript(_ index: Int) -> Element {
+        get {
+            return elements[index]
+        }
+        set {
+            elements[index] = newValue
+        }
     }
 }
 

--- a/NonEmptyArrayTests/NonEmptyArrayTests.swift
+++ b/NonEmptyArrayTests/NonEmptyArrayTests.swift
@@ -66,6 +66,12 @@ class NonEmptyArrayTests: XCTestCase {
         XCTAssertEqual(array[1..<2].first, 2)
     }
     
+    func testSubscriptMutation() {
+        var copy = array
+        copy[0] = 0
+        XCTAssertEqual(copy[0], 0, "A mutable Array should support subscript set operation.")
+    }
+    
     func testSequence() {
         let anySequence = AnySequence(array)
         let count = anySequence.reduce(0, { $0.0 + 1 })


### PR DESCRIPTION
This PR adds `MutableCollection` conformance to `NonEmptyArray`. It seems like a worthwhile addition to me since there is already support for other kinds of mutating operations and `Array` conforms to `MutableCollection`.